### PR TITLE
EXPLAIN updates

### DIFF
--- a/postpass/main.go
+++ b/postpass/main.go
@@ -12,7 +12,6 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/lib/pq"
 	"log"
 	"net/http"
 	"regexp"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	_ "github.com/lib/pq"
 )
 
 /* config stuff


### PR DESCRIPTION
This refactors the `EXPLAIN` logic to be in it's own function (for use in implementing #4. I have some things I want to discuss there before making a PR.) and use `FORMAT JSON` to avoid using regexes to parse the startup cost & total cost. 