### PR TITLE
Bugfix: close channel to prevent goroutine leak

### DIFF
--- a/postpass/main.go
+++ b/postpass/main.go
@@ -213,6 +213,7 @@ func handleApi(db *sql.DB, slow chan<- WorkItem, medium chan<- WorkItem, quick c
 	// create channel we want to receive the response on
 	rchan := make(chan SqlResponse, 1)
 	closeChan := make(chan struct{}, 1)
+	defer close(closeChan)
 
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	writer.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
I forgot that [the goroutine](https://github.com/woodpeck/postpass/blob/d4a44add750444bb83c05231259173049ca7b728/postpass/main.go#L75-L79) will stick around for normal (non-cancelled) requests and will create a leak over time. This fixes it, sorry!