### PR TITLE
feat(security): enforce read-only database transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ with anything else as well.
 See [woodpeck/postpass-ops](https://github.com/woodpeck/postpass-ops) for 
 docs on the instance of this software at `postpass.geofabrik.de`.
 
+## Security
+
+Postpass is designed to be a publicly accessible service. To prevent abuse, it is important to configure the database user with read-only permissions.
+
+For more information on security, see the [security documentation](postpass/README.md).
+
 ## Building
 
 A simple


### PR DESCRIPTION
Implement read-only transactions in both the  and  functions to prevent any potential write operations to the database. This enhances security by mitigating the risk of SQL injection attacks.

solves https://github.com/woodpeck/postpass/issues/12