### PR TITLE
Optional `Cache-Control` header in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * rename "properties" in GeoJSON FeatureCollection to "postpass_properties" in order to be GeoJSON compliant
 * rename "metadata" in JSON output to "postpass_properties" for consistency
 * Query can also be specified with the `q=` GET/POST param. `data=` still works
+* Add `cache_for` funtionality
 
 ## 0.2
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,24 @@ e.g.:
 
     curl -G http://localhost:8081/explain --data-urlencode "q=SELECT tags->>'name' as name, geom FROM postpass_point"
 
+
+#### `cache_for`
+
+For `GET` requests, if the parameter `cache_for` is a number, then the response
+will include a `Cache-Control: max-age=X` HTTP header.
+
+e.g.: The following response will have `Cache-Control: max-age=10000` response header.
+
+    curl -G http://localhost:8081/interpreter --data-urlencode "cache_for=10000" --data-urlencode "data=SELECT tags->>'name' as name, geom FROM postpass_point limit 1"
+
+> [!IMPORTANT]
+> postpass does not do any caching of responses. This option merely allows the
+> user to specify a header that any intermediate proxies might use.
+
+If `cache_for` is unset, `options[cache_for]` will be checked. These options
+have no effect on `POST` requests. Very high `cache_for` settings will be
+clamped to a sensible max value (currently: 2 days).
+
 ### LLM
 
 This prompt helps to generate good results with LLMs like ChatGPT.

--- a/postpass/handlers.go
+++ b/postpass/handlers.go
@@ -60,6 +60,23 @@ func HandleInterpreter(
 		geojson, _ = strconv.ParseBool(tGeojson[0])
 	}
 
+	if r.Method == http.MethodGet {
+		tCacheFor := r.Form["cache_for"]
+		if tCacheFor == nil {
+			tCacheFor = r.Form["options[cache_for]"]
+		}
+		if tCacheFor != nil {
+			parsed, _ := strconv.ParseUint(tCacheFor[0], 10, 64)
+			cache_for := uint(parsed)
+			// 2 days is 172,800. Longer caching is v. unlikely to be needed.
+			if cache_for > 172800 {
+				cache_for = 172800
+			}
+
+			writer.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", cache_for))
+		}
+	}
+
 	id := Count.Add(1)
 
 	log.Printf("request #%d: query '%s' g=%t\n", id,


### PR DESCRIPTION
This patch will use any `cache_for=N` parameter to cause a `Cache-Control: max-age=N` header to be added to the response. This could help intermediate proxies cache queries.

In Geofabrik, we proxy postpass via apache, and I would like to add simple caching at that level. I have not tested this yet.

This is a draft because I'm unsure about the naming conventions, or if it will work and if further headers are needed.