### PR TITLE
Handle databases without replication

### DIFF
--- a/postpass/worker.go
+++ b/postpass/worker.go
@@ -20,7 +20,7 @@ var Idle [4]atomic.Int64
  * arguments: database connection, worker id, channel to read jobs from
  */
 func Worker(db *sql.DB, id int, tasks <-chan WorkItem) {
-	var res string
+	var res string = ""
 	Idle[id/100].Add(1)
 
 	// reads job from channel
@@ -56,10 +56,13 @@ func Worker(db *sql.DB, id int, tasks <-chan WorkItem) {
         if err != nil {
             goto sqlerror
         }
-        rows.Next()
-        err = rows.Scan(&res)
-        if err != nil {
-            goto sqlerror
+
+        // if no rows are returned, no replication_timestamp has been set.
+        if (rows.Next()) {
+            err = rows.Scan(&res)
+            if err != nil {
+                goto sqlerror
+            }
         }
         _ = rows.Close()
 

--- a/postpass/worker.go
+++ b/postpass/worker.go
@@ -20,7 +20,6 @@ var Idle [4]atomic.Int64
  * arguments: database connection, worker id, channel to read jobs from
  */
 func Worker(db *sql.DB, id int, tasks <-chan WorkItem) {
-	var res string = ""
 	Idle[id/100].Add(1)
 
 	// reads job from channel
@@ -45,6 +44,7 @@ func Worker(db *sql.DB, id int, tasks <-chan WorkItem) {
         // A separate query is therefore needed to access the 
         // metadata.
 
+	var res string = ""
         var builder strings.Builder
         var comma string
         var line string


### PR DESCRIPTION
I followed the instructions for setting up postpass. I imported a small OSM dataset. Although I could query the database using psql, I just got an error `sql: Rows are closed` using postpass - as well as in the debug output on the server as well as result of a curl request.

I dug into the problem and found the solution: It was the query for the "replication_timestamp" which failed. I am not planning on using replication.

In this pull request I introduce a check for the return value of sql.Next() -> if false, an empty string will be printed as 'timestamp' in the result.