### PR TITLE
Don't error if there is no osm2pgsql_properties table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * rename "properties" in GeoJSON FeatureCollection to "postpass_properties" in order to be GeoJSON compliant
 * rename "metadata" in JSON output to "postpass_properties" for consistency
 * Query can also be specified with the `q=` GET/POST param. `data=` still works
+* Don't error if there is no `osm2psql_properties` table
 
 ## 0.2
 

--- a/postpass/worker.go
+++ b/postpass/worker.go
@@ -50,26 +50,31 @@ func Worker(db *sql.DB, id int, tasks <-chan WorkItem) {
 		var line string
 		var jsonfunc string
 
+		builder.WriteString("{ \n")
+		builder.WriteString(`"postpass_properties": { "generator": "Postpass API 0.2"`)
+
 		rows, err = db.QueryContext(taskCtx,
 			"SELECT value from osm2pgsql_properties where property='replication_timestamp'")
 
-		if err != nil {
-			goto sqlerror
-		}
+		if err == nil {
+			// If there is an error here, don't include `timestamp` property.
+			// this also supports databases which don't have this table.
 
-		// if no rows are returned, no replication_timestamp has been set.
-		if rows.Next() {
-			err = rows.Scan(&res)
-			if err != nil {
-				goto sqlerror
+			// if no rows are returned, no replication_timestamp has been set.
+			if rows.Next() {
+				err = rows.Scan(&res)
+				if err != nil {
+					goto sqlerror
+				}
 			}
-		}
-		_ = rows.Close()
+			_ = rows.Close()
 
-		builder.WriteString("{ \n")
-		builder.WriteString(`"postpass_properties": { "generator": "Postpass API 0.2", "timestamp": "`)
-		builder.WriteString(res)
-		builder.WriteString(`"}, `)
+			builder.WriteString(`, "timestamp": "`)
+			builder.WriteString(res)
+			builder.WriteString(`"`)
+		}
+
+		builder.WriteString(` }, `)
 		builder.WriteString("\n")
 		if task.geojson {
 			builder.WriteString(`"type": "FeatureCollection", "features" : [ `)


### PR DESCRIPTION
The [Postpass README](https://github.com/woodpeck/postpass#:~:text=Postpass%20itself%20is%20totally%20agnostic%20about%20the%20data%20you%20have%20in%20your%20database%20and%20you%20could%20theoretically%20use%20it%20with%20anything%20else%20as%20well%2E) says:

> Postpass itself is totally agnostic about the data you have in your database and you could theoretically use it with anything else as well.

However if you do not have a `osm2pgsql_properties` table, then you cannot use postpass, because it looks for this table to fill in the `timestamp` value.

This patch makes the absence or (or inaccessability of) this table no longer a fatal error. If this query succeeds, the `timestamp` value will be included. If not, this JSON property will simply not be included.