### PR TITLE
Instead of the data= GET/POST param, support q=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * drop "own_agg=false" option; we now always do the aggregation in the code, never in Postgres.
 * rename "properties" in GeoJSON FeatureCollection to "postpass_properties" in order to be GeoJSON compliant
 * rename "metadata" in JSON output to "postpass_properties" for consistency
+* Query can also be specified with the `q=` GET/POST param. `data=` still works
 
 ## 0.2
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ GET and POST requests are supported. Here's a simple test query that will load
 fast food POIs from your local osm2pgsql database. (schema is based on
 [postpass.geofabrik.de schema](https://github.com/woodpeck/postpass-ops)).
 
-    curl -G http://localhost:8081/interpreter --data-urlencode "data=
+    curl -G http://localhost:8081/interpreter --data-urlencode "q=
         SELECT tags->>'name' as name, geom 
         FROM postpass_point
         WHERE tags->>'amenity'='fast_food' 
@@ -149,7 +149,7 @@ A [PostgreSQL `EXPLAIN` output](https://www.postgresql.org/docs/current/sql-expl
 
 e.g.:
 
-    curl -G http://localhost:8081/explain --data-urlencode "data=SELECT tags->>'name' as name, geom FROM postpass_point"
+    curl -G http://localhost:8081/explain --data-urlencode "q=SELECT tags->>'name' as name, geom FROM postpass_point"
 
 ### LLM
 
@@ -186,7 +186,7 @@ Examples:
 
 1. Return geometries (default GeoJSON):
 
-> curl -G [https://postpass.geofabrik.de/api/0.2/interpreter](https://postpass.geofabrik.de/api/0.2/interpreter) --data-urlencode "data=
+> curl -G [https://postpass.geofabrik.de/api/0.2/interpreter](https://postpass.geofabrik.de/api/0.2/interpreter) --data-urlencode "q=
 > SELECT name, geom
 > FROM postpass\_point
 > WHERE tags->>'amenity' = 'fast\_food'
@@ -196,7 +196,7 @@ Examples:
 
 > curl -G [https://postpass.geofabrik.de/api/0.2/interpreter](https://postpass.geofabrik.de/api/0.2/interpreter)
 > \--data-urlencode "options\[geojson]=false"
-> \--data-urlencode "data=
+> \--data-urlencode "q=
 > SELECT
 > admin.tags->>'name' AS country,
 > COUNT(point.\*) AS ref\_count

--- a/postpass/handlers.go
+++ b/postpass/handlers.go
@@ -38,16 +38,21 @@ func HandleInterpreter(
 	writer.Header().Set("Server", "Postpass API 0.2")
 
 	// process GET/POST parameters
+	// Prefer q= then data=
 	_ = r.ParseForm()
-	tData := r.Form["data"]
-	if tData == nil {
-		log.Printf("no data field given\n")
-		http.Error(writer, "no data field given", http.StatusBadRequest)
+	query := ""
+	if values, ok := r.Form["q"] ; ok {
+		query = values[0]
+	} else if values, ok := r.Form["data"] ; ok {
+		query = values[0]
+	} else {
+		log.Printf("no q/data field given\n")
+		http.Error(writer, "no query field given", http.StatusBadRequest)
 		return
 	}
 
 	// Append a newline at the end to escape single line comments
-	query := tData[0] + "\n"
+	query = query + "\n"
 
 	geojson := true
 	tGeojson := r.Form["options[geojson]"]


### PR DESCRIPTION
query= is more logical and clear than data=

