### PR TITLE
Add /healthy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ If `cache_for` is unset, `options[cache_for]` will be checked. These options
 have no effect on `POST` requests. Very high `cache_for` settings will be
 clamped to a sensible max value (currently: 2 days).
 
+### `/healthy`
+
+Returns HTTP 200 and the text `healthy\n`. Useful for automated health checks.
+
 ### LLM
 
 This prompt helps to generate good results with LLMs like ChatGPT.

--- a/cmd/postpass/main.go
+++ b/cmd/postpass/main.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -131,6 +132,10 @@ func main() {
 	// set up callback for /explain URL
 	http.HandleFunc("/explain", func(w http.ResponseWriter, r *http.Request) {
 		postpass.HandleExplain(db, &cfg, w, r)
+	})
+
+	http.HandleFunc("/healthy", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "healthy\n")
 	})
 
 	log.Printf("Listening on :%d", cfg.ListenPort)


### PR DESCRIPTION
This should make it easier to detect when postpass.service is not running